### PR TITLE
Remove also hidden files

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,5 +2,18 @@
 
 set -e # fail on error
 
-# Credits https://unix.stackexchange.com/a/77313
-rm -rf ..?* .[!.]* *
+function clean {
+  WORKDIR=$1
+  echo "Cleaning $WORKDIR"
+  cd "$WORKDIR"
+  rm -rf ..?* .[!.]* *  # Credits https://unix.stackexchange.com/a/77313
+}
+
+clean "$(pwd)"
+clean "/__w"
+clean "/__e"
+clean "/__w/_temp"
+clean "/__w/_actions"
+clean "/__w/_tool"
+clean "/github/home"
+clean "/github/workflow"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,5 +2,5 @@
 
 set -e # fail on error
 
-rm -rf *
-
+# Credits https://unix.stackexchange.com/a/77313
+rm -rf ..?* .[!.]* *


### PR DESCRIPTION
The current implementation does not remove the hidden files. This can be a problem in the context of a github repository. The repo metadata is contained in the `.git` folder and if a job modifies that metadata, the modifications will persist from run to run even after the cleanup action is performed.