### PR TITLE
Use find to delete files instead of rm

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,5 +5,5 @@ set -e # fail on error
 # include hidden files 
 # https://askubuntu.com/questions/740805/how-can-i-remove-all-files-from-current-directory-using-terminal
 shopt -s dotglob
-rm -rf *
+find . -delete
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,8 +2,5 @@
 
 set -e # fail on error
 
-# include hidden files 
-# https://askubuntu.com/questions/740805/how-can-i-remove-all-files-from-current-directory-using-terminal
-shopt -s dotglob
 find . -delete
 


### PR DESCRIPTION
globbing may be a problem with big workspaces and files having names starting with dash
may be interpreted as a switch to rm. Using find resolves both issues.